### PR TITLE
Improvement: Added the ability to interprete triple quotation marks both single and double.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,7 @@ export function activate(context: vscode.ExtensionContext) {
       sendToJupyter(currentBlockCode);
     }
   );
+  
   let disposable2 = vscode.commands.registerCommand(
     "run-in-jupyter.justRun",
     () => {
@@ -35,42 +36,34 @@ export function activate(context: vscode.ExtensionContext) {
     }
   );
 
-  context.subscriptions.push(disposable1);
-  context.subscriptions.push(disposable2);
+  context.subscriptions.push(disposable1, disposable2);
 }
 
 // This method is called when your extension is deactivated
 export function deactivate() {}
+
 function moveToLineStart(lineNumber: number) {
   const editor = vscode.window.activeTextEditor;
   if (!editor) {
     return;
   }
-
   const position = new vscode.Position(lineNumber, 0);
   editor.selection = new vscode.Selection(position, position);
-
   editor.revealRange(new vscode.Range(position, position));
 }
+
 function insertEmptyLineAtEnd() {
   const editor = vscode.window.activeTextEditor;
   if (!editor) {
     return;
   }
-
   const document = editor.document;
   const lastLine = document.lineAt(document.lineCount - 1);
   const endOfDocument = lastLine.range.end;
 
-  editor
-    .edit((editBuilder) => {
-      editBuilder.insert(endOfDocument, "\n");
-    })
-    .then((success) => {
-      if (!success) {
-        vscode.window.showErrorMessage("error");
-      }
-    });
+  editor.edit((editBuilder) => {
+    editBuilder.insert(endOfDocument, "\n");
+  });
 }
 
 function getCurrentBlock(moveDown: boolean = true): string {
@@ -78,15 +71,25 @@ function getCurrentBlock(moveDown: boolean = true): string {
   if (!editor) {
     return "";
   }
+  
   const document = editor.document;
   const selection = editor.selection;
-  const cursorPosition = selection.active;
-
+  
+  // If there's an active selection, just return that
   if (!selection.isEmpty) {
-    const selectedText = document.getText(selection);
-    return selectedText;
+    return document.getText(selection);
   }
+
+  const cursorPosition = selection.active;
   const currentLine = document.lineAt(cursorPosition.line);
+  
+  // Check if we're inside a multiline string
+  const multilineStringInfo = isInsideMultilineString(document, cursorPosition);
+  if (multilineStringInfo) {
+    return handleMultilineString(document, multilineStringInfo, moveDown);
+  }
+
+  // Original logic for non-string blocks
   const indentLength = currentLine.firstNonWhitespaceCharacterIndex;
   const indent = currentLine.text.slice(0, indentLength);
   const pattern = new RegExp(
@@ -96,12 +99,11 @@ function getCurrentBlock(moveDown: boolean = true): string {
   const empty = new RegExp(`^\\s*#|^\\s*$`);
   const functionPattern = new RegExp(`^${indent}def\\s`);
   const classPattern = new RegExp(`^${indent}class\\s`);
+  
   let blockText = currentLine.text;
   let lineNumber;
-  if (
-    functionPattern.test(currentLine.text) ||
-    classPattern.test(currentLine.text)
-  ) {
+
+  if (functionPattern.test(currentLine.text) || classPattern.test(currentLine.text)) {
     for (lineNumber = cursorPosition.line - 1; lineNumber >= 0; lineNumber--) {
       const line = document.lineAt(lineNumber);
       if (decoratorPattern.test(line.text)) {
@@ -116,13 +118,9 @@ function getCurrentBlock(moveDown: boolean = true): string {
       }
     }
   }
-  let lastLineIsDecorator = false;
-  lastLineIsDecorator = decoratorPattern.test(currentLine.text);
-  for (
-    lineNumber = cursorPosition.line + 1;
-    lineNumber < document.lineCount;
-    lineNumber++
-  ) {
+
+  let lastLineIsDecorator = decoratorPattern.test(currentLine.text);
+  for (lineNumber = cursorPosition.line + 1; lineNumber < document.lineCount; lineNumber++) {
     const line = document.lineAt(lineNumber);
     if (empty.test(line.text)) {
       continue;
@@ -140,18 +138,102 @@ function getCurrentBlock(moveDown: boolean = true): string {
       break;
     }
   }
+
   if (moveDown) {
     if (lineNumber === document.lineCount) {
       const lastLine = document.lineAt(document.lineCount - 1);
-      if (empty.test(lastLine.text)) {
-        lineNumber--;
-      } else {
+      if (!empty.test(lastLine.text)) {
         insertEmptyLineAtEnd();
       }
     }
     moveToLineStart(lineNumber);
   }
+
   return blockText;
+}
+
+function isInsideMultilineString(document: vscode.TextDocument, position: vscode.Position): 
+  { startLine: number, endLine: number, quoteType: string } | null {
+  
+  const tripleQuotes = ['"""', "'''"];
+  let startLine: number | null = null;
+  let endLine: number | null = null;
+  let quoteType: string | null = null;
+  
+  // Check current line first
+  const currentLineText = document.lineAt(position.line).text;
+  for (const q of tripleQuotes) {
+    const firstQuoteIndex = currentLineText.indexOf(q);
+    if (firstQuoteIndex >= 0 && firstQuoteIndex < position.character) {
+      const remainingText = currentLineText.substring(firstQuoteIndex + q.length);
+      if (remainingText.includes(q)) {
+        // Single line triple quote - not a multiline string
+        return null;
+      } else {
+        startLine = position.line;
+        quoteType = q;
+        break;
+      }
+    }
+  }
+  
+  // If not found on current line, search backwards
+  if (startLine === null) {
+    for (let line = position.line; line >= 0; line--) {
+      const lineText = document.lineAt(line).text;
+      for (const q of tripleQuotes) {
+        if (lineText.includes(q)) {
+          // Check if it's an opening quote (odd number of quotes before it)
+          const quotesBefore = (lineText.match(new RegExp(q, 'g')) || []).length;
+          if (quotesBefore % 2 === 1) {
+            startLine = line;
+            quoteType = q;
+            break;
+          }
+        }
+      }
+      if (quoteType !== null) break;
+    }
+  }
+  
+  if (quoteType === null || startLine === null) return null;
+  
+  // Find the closing quote
+  for (let line = startLine; line < document.lineCount; line++) {
+    const lineText = document.lineAt(line).text;
+    if (line > startLine && lineText.includes(quoteType)) {
+      endLine = line;
+      break;
+    }
+  }
+  
+  if (endLine === null) return null;
+  
+  return { startLine, endLine, quoteType };
+}
+
+function handleMultilineString(
+  document: vscode.TextDocument, 
+  info: { startLine: number, endLine: number, quoteType: string },
+  moveDown: boolean
+): string {
+  let blockText = '';
+  
+  for (let line = info.startLine; line <= info.endLine; line++) {
+    blockText += document.lineAt(line).text + '\n';
+  }
+  
+  if (moveDown) {
+    const nextLine = info.endLine + 1;
+    if (nextLine < document.lineCount) {
+      moveToLineStart(nextLine);
+    } else {
+      insertEmptyLineAtEnd();
+      moveToLineStart(nextLine);
+    }
+  }
+  
+  return blockText.trim();
 }
 
 function sendToJupyter(code: string) {


### PR DESCRIPTION
Now, by placing the cursor on a multiline string of any kind, vscode is going to send the full block to be run on python interactive kernel.

It works with regular multiline strings such as """ """ or ''' '''. It will also work on fstrings or other variations..

Samples that works:
"""
Some text here
Some text there
"""

x = """
Some text here
Some text there
"""

x = f"""
Some text {here}
Some text {there}
"""